### PR TITLE
Allow more flexible spice directory structures

### DIFF
--- a/mavenpy/anc.py
+++ b/mavenpy/anc.py
@@ -166,6 +166,8 @@ def read_orbit_ephemeris(data_directory,
                          start_date=None, end_date=None, n_days=None,
                          only_over_timerange=None,
                          mirror_spedas_dir_tree=True,
+                         generic_in_local_spice_dir=False,
+                         custom_maven_kernel_dir=None,
                          fields=None,
                          download_if_not_available=True,
                          prompt_for_download=True):
@@ -190,6 +192,8 @@ def read_orbit_ephemeris(data_directory,
         spk_ext='orb',
         use_most_recent=None,
         mirror_spedas_dir_tree=mirror_spedas_dir_tree,
+        generic_in_local_spice_dir=generic_in_local_spice_dir,
+        custom_maven_kernel_dir=custom_maven_kernel_dir,
         prompt_for_download=prompt_for_download)
 
     if isinstance(paths, str):

--- a/mavenpy/spice.py
+++ b/mavenpy/spice.py
@@ -192,6 +192,8 @@ def find_local_files(local_dir, kernel_group, kernel_name,
                      ck_platform=None,
                      use_most_recent=None,
                      mirror_spedas_dir_tree=True,
+                     generic_in_local_spice_dir=False,
+                     custom_maven_kernel_dir=None,
                      verbose=None):
 
     ''' Returns local files matching a given format.
@@ -205,6 +207,19 @@ def find_local_files(local_dir, kernel_group, kernel_name,
     mirror_spedas_file_tree: boolean, True/False if searching/creating
         spice kernels in the same subdirectory where SPEDAS saves them
         (root_dir + "/misc/spice/naif/" based on spice_file_source.pro)
+    generic_in_local_spice_dir: boolean
+                                if True and mirror_spedas_dir_tree=False, 
+                                the generic_kernels folder will be taken to be 
+                                in the user's local spice directory. If False,
+                                an intermediate directory structure will be used for 
+                                generic kernels (misc/spice/naif), like this:
+                                                     |              |
+                                                     v              v
+                               /users_spice_root_dir/misc/spice/naif/generic_kernels/
+    custom_maven_kernel_dir : str or None
+                              If not None and mirror_spedas_dir_tree=False, 
+                              this string will replace 'MAVEN/kernels'. Allows
+                              unusual directory structures used by other teams.
     '''
     # print(kernel_group, kernel_name)
 
@@ -238,7 +253,7 @@ def find_local_files(local_dir, kernel_group, kernel_name,
         kernel_name_split = kernel_name_split[:-1]
     subpath = (*subpath, *kernel_name_split)
 
-    if mirror_spedas_dir_tree:
+    if mirror_spedas_dir_tree or generic_in_local_spice_dir:
         local_dir_i = os.path.join(local_dir, *subpath)
     else:
         # 2/11/25: If not mirroring SPEDAS (which keeps
@@ -247,7 +262,14 @@ def find_local_files(local_dir, kernel_group, kernel_name,
         # all MAVEN-related kernels only identified by kernel type
         # (e.g. spk, lsk), then only make a directory for that
         # subtype and save everything there.
+        # (This assumes generic_kernels is located in /local_dir/misc/spice/naif):
         local_dir_i = os.path.join(local_dir, kernel_name_split[0])
+        
+    # Handle a special case where IUVS are special snowflakes and have a
+    # different maven directory structure. --added by Eryn (IUVS team member)
+    if custom_maven_kernel_dir is not None:
+        local_dir_i = local_dir_i.replace('MAVEN/kernels', custom_maven_kernel_dir)
+    
     if verbose:
         print("Searching in:", local_dir_i)
 
@@ -489,6 +511,8 @@ def retrieve_kernels(data_directory, kernel_group, kernel_name,
                      download_if_not_available=True,
                      ck_platform=None, spk_ext='bsp',
                      use_most_recent=None, mirror_spedas_dir_tree=True,
+                     generic_in_local_spice_dir=False,
+                     custom_maven_kernel_dir=None,
                      session=None,
                      verbose=None,
                      prompt_for_download=True):
@@ -518,6 +542,8 @@ def retrieve_kernels(data_directory, kernel_group, kernel_name,
         ck_platform=ck_platform,
         use_most_recent=use_most_recent,
         mirror_spedas_dir_tree=mirror_spedas_dir_tree,
+        generic_in_local_spice_dir=generic_in_local_spice_dir,
+        custom_maven_kernel_dir=custom_maven_kernel_dir,
         verbose=verbose)
 
     local_savedir = local_info["local_dir"]
@@ -807,6 +833,8 @@ def MAVEN_kernels(data_directory, kernels, kernel_groups,
                   download_if_not_available=True,
                   session=None, verbose=None,
                   mirror_spedas_dir_tree=True,
+                  generic_in_local_spice_dir=False,
+                  custom_maven_kernel_dir=None,
                   spk_ext='bsp',
                   prompt_for_download=True):
 
@@ -852,6 +880,8 @@ def MAVEN_kernels(data_directory, kernels, kernel_groups,
             verbose=verbose,
             spk_ext=spk_ext, ck_platform=ck_platform,
             mirror_spedas_dir_tree=mirror_spedas_dir_tree,
+            generic_in_local_spice_dir=generic_in_local_spice_dir,
+            custom_maven_kernel_dir=custom_maven_kernel_dir, 
             prompt_for_download=prompt_for_download)
 
         kernel_filepath += kernel_filepath_i
@@ -867,6 +897,8 @@ def load_kernels(data_directory,
                  kernels=None,
                  download_if_not_available=True,
                  mirror_spedas_dir_tree=True,
+                 generic_in_local_spice_dir=False,
+                 custom_maven_kernel_dir=None,
                  verbose=None,
                  load_spacecraft=True,
                  load_spacecraft_pointing=True,
@@ -914,6 +946,8 @@ def load_kernels(data_directory,
         start_dt=start_dt, end_dt=end_dt,
         download_if_not_available=download_if_not_available,
         mirror_spedas_dir_tree=mirror_spedas_dir_tree,
+        generic_in_local_spice_dir=generic_in_local_spice_dir,
+        custom_maven_kernel_dir=custom_maven_kernel_dir,
         verbose=verbose,
         prompt_for_download=prompt_for_download)
 


### PR DESCRIPTION
On the IUVS team we use a different default spice directory structure that looks like this:

```
/path/to/spice/generic_kernels/
|____fk
|____lsk
|____pck
|____sclk
|____spk
/path/to/spice/mvn/
|____ck
|____combined
|____fk
|____ik
|____lsk
|____meta
|____old_mirror
|____pck
|____sclk
|____spk
```

Currently in mavenpy, if `mirror_spedas_dir_tree=False`, the following structure (or something like it, can't recall if a folder called `generic_kernels` is appended after `naif/`) is used:

```
/path/to/spice/misc/spice/naif/
|____fk
...etc
/path/to/spice/MAVEN/kernels/
|____ck
...etc
```

These updates accommodate the IUVS structure with two additional arguments:
- `generic_in_local_spice_dir`
- `custom_maven_kernel_dir`

 The argument default values have been set to False and None to prevent breakage of existing codebases.

Note that this does not remove the subdirectories `satellites`, `planets` etc that appear in the generic kernels. I thought about it because we don't use those on IUVS apparently but it seemed to be too much of a rabbithole to think about.

Please review and let me know if this looks sensible and non-breaking for PFP users!